### PR TITLE
Automate application autostart setup via cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,6 +2159,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "whatawhat-lib",
+ "winreg",
  "zstd",
 ]
 
@@ -2333,6 +2334,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2486,6 +2496,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ ansi_term = "0.12.1"
 whatawhat-lib = { git = "https://github.com/Anoromi/whatawhat-lib", branch = "with-app-names" }
 zstd = "0.13.3"
 
+[target.'cfg(windows)'.dependencies]
+winreg = "0.52"
+
 [target.'cfg(unix)'.dependencies]
 daemonize = { version = "0.5.0" }
 

--- a/README.md
+++ b/README.md
@@ -89,17 +89,15 @@ whatawhat timeline -d 1 -o minutes --start "today" --days | grep YouTube
 
 ## Autostart
 
-Whatawhat doesn't run startup by default. This needs to be configured yourself.
+You can enable autostart in one command:
 
-For Windows you can refer to [this](https://www.howtogeek.com/208224/how-to-add-a-program-to-startup-in-windows/):
- - Create a shortcut to whatawhat-daemon.exe.
- - Put the shortcut into the startup folder.
- - The daemon will now autostart on boot.
+```
+whatawhat autostart
+```
 
-On Linux it's best to use autostart utilities provided by Gnome, KDE Plasma, etc.:
- - Add a new process on startup.
- - Specify the full path to the daemon (Usually `/home/username/.cargo/bin/whatawhat-daemon`).
- - The daemon will now autostart on boot.
+- On **Windows**, this creates an entry under `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` to start `whatawhat-daemon` on login.
+- On **Linux**, this creates a `~/.config/autostart/whatawhat-daemon.desktop` file pointing to the `whatawhat-daemon` binary.
+- macOS autostart is not implemented.
 
 ## Notes
 

--- a/src/cli/autostart.rs
+++ b/src/cli/autostart.rs
@@ -1,0 +1,56 @@
+use std::{env, fs, io, path::PathBuf};
+
+use anyhow::{anyhow, Context, Result};
+
+use crate::cli::daemon_path::to_daemon_path;
+
+pub fn configure_autostart() -> Result<()> {
+    let daemon_path = to_daemon_path(env::current_exe().context("Failed to get current executable")?);
+
+    #[cfg(target_os = "linux")]
+    {
+        configure_autostart_linux(&daemon_path)?;
+        println!("Autostart configured: created ~/.config/autostart/whatawhat-daemon.desktop -> {:?}", daemon_path);
+        return Ok(());
+    }
+
+    #[cfg(windows)]
+    {
+        configure_autostart_windows(&daemon_path)?;
+        println!("Autostart configured: added HKCU Run entry for {:?}", daemon_path);
+        return Ok(());
+    }
+
+    #[allow(unreachable_code)]
+    Err(anyhow!("Autostart is not supported on this OS"))
+}
+
+#[cfg(target_os = "linux")]
+fn configure_autostart_linux(daemon_path: &PathBuf) -> Result<()> {
+    let home = env::var("HOME").context("HOME not set")?;
+    let autostart_dir = PathBuf::from(home).join(".config").join("autostart");
+    fs::create_dir_all(&autostart_dir).with_context(|| format!("Failed to create {:?}", autostart_dir))?;
+
+    let desktop_file_path = autostart_dir.join("whatawhat-daemon.desktop");
+    let contents = format!(
+        "[Desktop Entry]\nType=Application\nName=Whatawhat Daemon\nExec={}\nX-GNOME-Autostart-enabled=true\nHidden=false\n",
+        daemon_path.display()
+    );
+    fs::write(&desktop_file_path, contents)
+        .with_context(|| format!("Failed writing {:?}", desktop_file_path))?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn configure_autostart_windows(daemon_path: &PathBuf) -> Result<()> {
+    use winreg::enums::*;
+    use winreg::RegKey;
+
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let (run, _disp) = hkcu.create_subkey("Software\\Microsoft\\Windows\\CurrentVersion\\Run")?;
+    // Quote the path in case of spaces
+    let value: String = format!("\"{}\"", daemon_path.display());
+    run.set_value("Whatawhat", &value)?;
+    Ok(())
+}
+

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@ pub mod output;
 pub mod process;
 pub mod timeline;
 pub mod subprocess_window_collector;
+pub mod autostart;
 
 use std::{env, ffi::OsString, path::PathBuf};
 
@@ -12,6 +13,7 @@ use daemon_path::to_daemon_path;
 use process::{kill_previous_daemons, restart_daemon};
 use timeline::{TimelineCommand, app_timeline_command};
 use tracing::level_filters::LevelFilter;
+use autostart::configure_autostart;
 
 use crate::utils::{
         dir::create_application_default_path,
@@ -39,6 +41,8 @@ struct Args {
 enum Commands {
     #[command(about = "Starts a daemon for the application")]
     Restart {},
+    #[command(about = "Enable autostart of the daemon on system login (Windows/Linux)")]
+    Autostart {},
     #[command(about = "Display a timeline of user activity")]
     Timeline {
         #[command(flatten)]
@@ -71,6 +75,10 @@ pub fn run_cli(values: impl Iterator<Item = OsString>) -> Result<()> {
     match args.commands {
         Commands::Restart { .. } => {
             restart_daemon()?;
+            Ok(())
+        }
+        Commands::Autostart {} => {
+            configure_autostart()?;
             Ok(())
         }
         Commands::Stop {} => {


### PR DESCRIPTION
Add `whatawhat autostart` CLI command to automatically configure daemon startup on Windows and Linux.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c9caf64-0b2e-473a-bb9e-cb0635634fe9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0c9caf64-0b2e-473a-bb9e-cb0635634fe9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

